### PR TITLE
Remove ResponseWriter arg from handler func

### DIFF
--- a/handlers/endpoints/endpoints.go
+++ b/handlers/endpoints/endpoints.go
@@ -12,7 +12,7 @@ import (
 
 // HandlerFunc is type of function used to handle http requests and has
 // additional endpoint.Context
-type HandlerFunc func(http.ResponseWriter, *http.Request, context.Context)
+type HandlerFunc func(*http.Request, context.Context)
 
 // Endpoint is the type required to define an endpoint
 type Endpoint struct {
@@ -26,7 +26,7 @@ type Endpoint struct {
 func (e Endpoint) Attach(r *mux.Router) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.New(e.Name, w, r)
-		e.Handler(w, r, ctx)
+		e.Handler(r, ctx)
 	}
 	handler = middleware.Log(handler)
 	handler = middleware.Metrics(e.Name, handler)

--- a/handlers/endpoints/users/create.go
+++ b/handlers/endpoints/users/create.go
@@ -20,7 +20,7 @@ var CreateEndpoint = endpoints.Endpoint{
 	Methods: []string{http.MethodPost},
 }
 
-func handleUserCreate(w http.ResponseWriter, req *http.Request, ctx context.Context) {
+func handleUserCreate(req *http.Request, ctx context.Context) {
 	if req.Method != http.MethodPost {
 		// This shouldn't be possible given that the route only accepts POST requests
 		ctx.Logger().WithField("method", req.Method).Error("Invalid method for users#create")


### PR DESCRIPTION
This can be removed because the Context has a responseWriter and
it is never needed by the handler.